### PR TITLE
Removing need for appcompat and tweaking screen contrast

### DIFF
--- a/app/jni/TI85.c
+++ b/app/jni/TI85.c
@@ -38,6 +38,10 @@
 #define ftell           gztell
 #endif
 
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define FITWITHIN(x, l, h) (MIN(MAX(x, l), h))
+
 /** User-defined parameters for ATI85 ************************/
 int  Mode      = 0;          /* Various operating mode bits  */
 byte Verbose   = 3;          /* Debug messages ON/OFF switch */
@@ -862,10 +866,21 @@ void TI85Colors(register byte V)
 
 void TI83Colors(register byte V)
 {
-  V = 0x7F-((V&0x3F)<<1);
-  SetColor(1,V,V,V+0x20);
-  V = 0xFF-V;
-  SetColor(0,V-0x08,V,V-0x08);
+  /* Setting pixel colors for screen to emulate
+     low and high battery */
+  int pxOn = 255 - MIN((((V&0x3F)-20)*10)+0, 254);
+  byte pxOnR = (byte) FITWITHIN(pxOn, 1, 191);
+  byte pxOnG = (byte) FITWITHIN(pxOn, 1, 199);
+  byte pxOnB = (byte) FITWITHIN(pxOn, 33, 191);
+  int pxOff = 511 - MAX((((V&0x3F)-12)*10)+0, 254);
+  byte pxOffR = (byte) FITWITHIN(pxOff, 1, 191);
+  byte pxOffG = (byte) FITWITHIN(pxOff, 1, 199);
+  byte pxOffB = (byte) FITWITHIN(pxOff, 33, 191);
+
+  // Setting the color for turned on pixels
+  SetColor(1, pxOnR, pxOnG, pxOnB);
+  // Setting the color for turned off pixels
+  SetColor(0, pxOffR, pxOffG, pxOffB);
 }
 
 /** TI8*Page() ***********************************************/

--- a/app/src/main/java/net/supware/tipro/Ti8xActivity.java
+++ b/app/src/main/java/net/supware/tipro/Ti8xActivity.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import android.app.AlertDialog;
@@ -130,12 +131,6 @@ public abstract class Ti8xActivity extends FullScreenActivity {
 
 			case MotionEvent.ACTION_DOWN:
 			case MotionEvent.ACTION_POINTER_DOWN:
-			case MotionEvent.ACTION_MOVE:
-				// Check if moving off a pressed button
-				if (mPressedButtons.containsKey(pointerId)
-					&& !mPressedButtons.get(pointerId).rect.contains(p.x, p.y)) {
-					keyUp(pointerId);
-				}
 
 				TIButton currentButton = mSkinModel.getButtonAt(p);
 				// Check if clicking or moving onto a new button
@@ -143,6 +138,37 @@ public abstract class Ti8xActivity extends FullScreenActivity {
 					&& (currentButton != null)) {
 					mPressedButtons.put(pointerId, currentButton);
 					keyDown(pointerId);
+				}
+
+				break;
+
+			case MotionEvent.ACTION_MOVE:
+				int pointerCount = event.getPointerCount();
+				HashMap<Integer, TIButton> currentButtons = new HashMap<Integer, TIButton>();
+				for(int i = 0; i < pointerCount; ++i)
+				{
+					pointerIndex = i;
+					pointerId = event.getPointerId(pointerIndex);
+					p = mSkinView.screenToButton((int) event.getX(pointerIndex),
+												 (int) event.getY(pointerIndex));
+					currentButtons.put(pointerId, mSkinModel.getButtonAt(p));
+				}
+				ArrayList<Integer> noLongerHeldButtons = new ArrayList<Integer>();
+				for (HashMap.Entry<Integer, TIButton> entry : mPressedButtons.entrySet()) {
+					if (entry.getValue() != null & !currentButtons.containsValue(entry.getValue()))
+					{
+						noLongerHeldButtons.add(entry.getKey());
+					}
+				}
+				for (int i = 0; i < noLongerHeldButtons.size() ; i++) {
+					keyUp(noLongerHeldButtons.get(i));
+				}
+				for (HashMap.Entry<Integer, TIButton> entry : currentButtons.entrySet()) {
+					if (entry.getValue() != null & !mPressedButtons.containsValue(entry.getValue()))
+					{
+						mPressedButtons.put(entry.getKey(), entry.getValue());
+						keyDown(entry.getKey());
+					}
 				}
 
 				break;

--- a/app/src/main/java/net/supware/tipro/view/SkinView.java
+++ b/app/src/main/java/net/supware/tipro/view/SkinView.java
@@ -1,5 +1,7 @@
 package net.supware.tipro.view;
 
+import java.util.HashMap;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -78,8 +80,8 @@ public class SkinView extends View {
 	/**
 	 * Region to display pressed button (relative to screen)
 	 */
-	RectF mPressedButtonRectF;
-	Rect mInvalidateRect;
+	HashMap<TIButton, RectF> mPressedButtonsRectF = new HashMap<TIButton, RectF>();
+	HashMap<TIButton, Rect> mInvalidateRects = new HashMap<TIButton, Rect>();
 
 	public SkinView(Context context, AttributeSet attributes) {
 		super(context, attributes);
@@ -217,35 +219,35 @@ public class SkinView extends View {
 		canvas.drawBitmap(mSkinBitmap, mSkinButtonDrawableRegion,
 				mViewButtonDrawableRegion, mSkinPaint);
 
-		// If a button is pressed, draw that
-		if (mPressedButtonRectF != null) {
-			canvas.drawRoundRect(mPressedButtonRectF, 5, 5, mButtonPaint);
+		// If one or more buttons are pressed, draw that
+		for (HashMap.Entry<TIButton, RectF> entry : mPressedButtonsRectF.entrySet()) {
+			canvas.drawRoundRect(entry.getValue(), 5, 5, mButtonPaint);
 		}
 	}
 
 	public void setPressedButton(TIButton button) {
-		mInvalidateRect = transformRect(button.rect, mSkinButtonRegion,
-				mViewButtonRegion);
-		mPressedButtonRectF = new RectF(mInvalidateRect);
+		mInvalidateRects.put(button, transformRect(button.rect, mSkinButtonRegion,
+				mViewButtonRegion));
+		mPressedButtonsRectF.put(button, new RectF(mInvalidateRects.get(button)));
 
 		// Add a 2 pixel border, to be safe
-		mInvalidateRect.inset(-2, -2);
+		mInvalidateRects.get(button).inset(-2, -2);
 
 		// Copy mInvalidateRect because .invalidate is destructive
-		Rect dirty = new Rect(mInvalidateRect);
+		Rect dirty = new Rect(mInvalidateRects.get(button));
 		this.invalidate(dirty);
 	}
 
-	public void clearPressedButton() {
-		mPressedButtonRectF = null;
+	public void clearPressedButton(TIButton button) {
+		mPressedButtonsRectF.remove(button);
 
-		if (mInvalidateRect != null) {
+		if (mInvalidateRects.containsKey(button)) {
 
 			// Copy mInvalidateRect because .invalidate is destructive
-			Rect dirty = new Rect(mInvalidateRect);
+			Rect dirty = new Rect(mInvalidateRects.get(button));
 			this.invalidate(dirty);
 
-			mInvalidateRect = null;
+			mInvalidateRects.remove(button);
 		}
 	}
 

--- a/app/src/main/jni/TI85.c
+++ b/app/src/main/jni/TI85.c
@@ -38,6 +38,10 @@
 #define ftell           gztell
 #endif
 
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define FITWITHIN(x, l, h) (MIN(MAX(x, l), h))
+
 /** User-defined parameters for ATI85 ************************/
 int  Mode      = 0;          /* Various operating mode bits  */
 byte Verbose   = 3;          /* Debug messages ON/OFF switch */
@@ -862,10 +866,21 @@ void TI85Colors(register byte V)
 
 void TI83Colors(register byte V)
 {
-  V = 0x7F-((V&0x3F)<<1);
-  SetColor(1,V,V,V+0x20);
-  V = 0xFF-V;
-  SetColor(0,V-0x08,V,V-0x08);
+  /* Setting pixel colors for screen to emulate
+     low and high battery */
+  int pxOn = 255 - MIN((((V&0x3F)-20)*10)+0, 254);
+  byte pxOnR = (byte) FITWITHIN(pxOn, 1, 191);
+  byte pxOnG = (byte) FITWITHIN(pxOn, 1, 199);
+  byte pxOnB = (byte) FITWITHIN(pxOn, 33, 191);
+  int pxOff = 511 - MAX((((V&0x3F)-12)*10)+0, 254);
+  byte pxOffR = (byte) FITWITHIN(pxOff, 1, 191);
+  byte pxOffG = (byte) FITWITHIN(pxOff, 1, 199);
+  byte pxOffB = (byte) FITWITHIN(pxOff, 33, 191);
+
+  // Setting the color for turned on pixels
+  SetColor(1, pxOnR, pxOnG, pxOnB);
+  // Setting the color for turned off pixels
+  SetColor(0, pxOffR, pxOffG, pxOffB);
 }
 
 /** TI8*Page() ***********************************************/

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,8 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+	
+    <style name="AppTheme" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
Changing path to style parent (DarkActionBar) to manage building without appcompat.

Making contrast settings being able to overpower/underpower screen, feature used by some applications to fade graphics.